### PR TITLE
Rozwiązanie zadania by me

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,12 +22,12 @@ module.exports = {
     module: {
         loaders: [
             {
-                test: /\.json/,
+                test: /\.json$/,
                 exclude: /executor\/node_modules/,
                 loader: 'json-loader'
             },
             {
-                test: /\.js/,
+                test: /\.js$/,
                 exclude: /executor\/node_modules/,
                 loader: 'babel-loader',
                 query: {


### PR DESCRIPTION
Wyrażenie regularne łapiące rozszerzenie `.js` pasuje również dla frazy `.json` - aby uniknąć nieporozumień należy określić, że spodziewamy danego wyrażenia na końcu łancucha.
